### PR TITLE
use bcrypt pkg instead in hashing

### DIFF
--- a/backend/internal/auth.go
+++ b/backend/internal/auth.go
@@ -1,32 +1,17 @@
 package internal
 
 import (
-	"bytes"
-	"crypto/rand"
-	"crypto/sha256"
-	"io"
+	"golang.org/x/crypto/bcrypt"
 )
-
-var saltLen = 5
 
 // HashAndSaltPassword hashes given password and append salt to it
 func HashAndSaltPassword(password []byte) ([]byte, error) {
-	salt := make([]byte, saltLen)
-	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
-		return []byte{}, err
-	}
+	return bcrypt.GenerateFromPassword(password, bcrypt.DefaultCost)
 
-	hashedPassword := sha256.Sum256(append(salt, password...))
-	return append(salt, hashedPassword[:]...), nil
 }
 
 // VerifyPassword checks if given password is same as hashed one
 func VerifyPassword(hashedPassword []byte, password string) bool {
-	hashedPasswordCopy := make([]byte, len(hashedPassword))
+	return bcrypt.CompareHashAndPassword(hashedPassword, []byte(password)) == nil
 
-	copy(hashedPasswordCopy, hashedPassword)
-	salt := hashedPasswordCopy[:saltLen]
-
-	checkedPass := sha256.Sum256(append(salt, []byte(password)...))
-	return bytes.Equal(append(salt, checkedPass[:]...), hashedPassword)
 }


### PR DESCRIPTION
### Description

- use bcrypt pkg in hashing password.
### Changes

List of changes this PR includes

### Related Issues

- https://github.com/codescalers/kubecloud/issues/139
### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
