### PR TITLE
Support maintenance mode status in backend 

### DIFF
--- a/backend/app/admin_handler.go
+++ b/backend/app/admin_handler.go
@@ -354,7 +354,7 @@ func (h *Handler) ListPendingRecordsHandler(c *gin.Context) {
 // @ID set-maintenance-mode
 // @Accept json
 // @Produce json
-// @Param body body SetMaintenanceModeInput true "Set Maintenance Mode Input"
+// @Param body body MaintenanceModeStatus true "Maintenance Mode Status"
 // @Success 200 {object} APIResponse
 // @Failure 500 {object} APIResponse
 // @Security AdminMiddleware

--- a/backend/app/admin_handler.go
+++ b/backend/app/admin_handler.go
@@ -41,7 +41,7 @@ type PendingRecordsResponse struct {
 	TransferredUSDAmount float64 `json:"transferred_usd_amount"`
 }
 
-type SetMaintenanceModeInput struct {
+type MaintenanceModeStatus struct {
 	Enabled bool `json:"enabled"`
 }
 
@@ -361,7 +361,7 @@ func (h *Handler) ListPendingRecordsHandler(c *gin.Context) {
 // @Router /system/maintenance/status [post]
 // SetMaintenanceModeHandler sets maintenance mode for the system
 func (h *Handler) SetMaintenanceModeHandler(c *gin.Context) {
-	var request SetMaintenanceModeInput
+	var request MaintenanceModeStatus
 
 	// check on request format
 	if err := c.ShouldBindJSON(&request); err != nil {
@@ -405,7 +405,7 @@ func (h *Handler) GetMaintenanceModeHandler(c *gin.Context) {
 		return
 	}
 
-	Success(c, http.StatusOK, "Maintenance mode is retrieved successfully", map[string]interface{}{
-		"enabled": enabled,
+	Success(c, http.StatusOK, "Maintenance mode is retrieved successfully", MaintenanceModeStatus{
+		Enabled: enabled,
 	})
 }

--- a/backend/app/admin_handler_test.go
+++ b/backend/app/admin_handler_test.go
@@ -483,9 +483,10 @@ func TestMaintenanceModeIntegration(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer "+token)
 		resp := httptest.NewRecorder()
 		router.ServeHTTP(resp, req)
-		assert.Equal(t, http.StatusOK, resp.Code)
+		require.Equal(t, http.StatusOK, resp.Code)
 
 		result := extractMaintenanceModeStatus(t, resp.Body)
+		require.False(t, result.Enabled)
 
 		payload := MaintenanceModeStatus{Enabled: true}
 		body, _ := json.Marshal(payload)
@@ -494,17 +495,17 @@ func TestMaintenanceModeIntegration(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 		resp = httptest.NewRecorder()
 		router.ServeHTTP(resp, req)
-		assert.Equal(t, http.StatusOK, resp.Code)
+		require.Equal(t, http.StatusOK, resp.Code)
 
 		// 3. Verify it's enabled
 		req, _ = http.NewRequest("GET", "/api/v1/system/maintenance/status", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 		resp = httptest.NewRecorder()
 		router.ServeHTTP(resp, req)
-		assert.Equal(t, http.StatusOK, resp.Code)
+		require.Equal(t, http.StatusOK, resp.Code)
 
 		result = extractMaintenanceModeStatus(t, resp.Body)
-		assert.True(t, result.Enabled)
+		require.True(t, result.Enabled)
 
 		payload = MaintenanceModeStatus{Enabled: false}
 		body, _ = json.Marshal(payload)
@@ -513,16 +514,16 @@ func TestMaintenanceModeIntegration(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 		resp = httptest.NewRecorder()
 		router.ServeHTTP(resp, req)
-		assert.Equal(t, http.StatusOK, resp.Code)
+		require.Equal(t, http.StatusOK, resp.Code)
 
 		req, _ = http.NewRequest("GET", "/api/v1/system/maintenance/status", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 		resp = httptest.NewRecorder()
 		router.ServeHTTP(resp, req)
-		assert.Equal(t, http.StatusOK, resp.Code)
+		require.Equal(t, http.StatusOK, resp.Code)
 
 		result = extractMaintenanceModeStatus(t, resp.Body)
-		assert.False(t, result.Enabled)
+		require.False(t, result.Enabled)
 	})
 }
 

--- a/backend/app/app.go
+++ b/backend/app/app.go
@@ -225,6 +225,13 @@ func (app *App) registerHandlers() {
 
 		}
 
+		systemGroup := adminGroup.Group("/system")
+		systemGroup.Use(middlewares.AdminMiddleware(app.handlers.tokenManager))
+		{
+			systemGroup.POST("/maintenance/status", app.handlers.SetMaintenanceModeHandler)
+			systemGroup.GET("/maintenance/status", app.handlers.GetMaintenanceModeHandler)
+		}
+
 		userGroup := v1.Group("/user")
 		{
 			userGroup.POST("/register", app.handlers.RegisterHandler)

--- a/backend/app/app.go
+++ b/backend/app/app.go
@@ -202,6 +202,7 @@ func (app *App) registerHandlers() {
 	{
 		v1.GET("/nodes", app.handlers.ListNodesHandler)
 		v1.GET("/workflow/:workflow_id", app.handlers.GetWorkflowStatus)
+		v1.GET("/system/maintenance/status", app.handlers.GetMaintenanceModeHandler)
 
 		adminGroup := v1.Group("")
 		adminGroup.Use(middlewares.AdminMiddleware(app.handlers.tokenManager))
@@ -229,7 +230,6 @@ func (app *App) registerHandlers() {
 		systemGroup.Use(middlewares.AdminMiddleware(app.handlers.tokenManager))
 		{
 			systemGroup.POST("/maintenance/status", app.handlers.SetMaintenanceModeHandler)
-			systemGroup.GET("/maintenance/status", app.handlers.GetMaintenanceModeHandler)
 		}
 
 		userGroup := v1.Group("/user")

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -153,6 +153,85 @@ const docTemplate = `{
                 }
             }
         },
+        "/system/maintenance/status": {
+            "get": {
+                "security": [
+                    {
+                        "AdminMiddleware": []
+                    }
+                ],
+                "description": "Gets maintenance mode for the system",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Get maintenance mode",
+                "operationId": "get-maintenance-mode",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "AdminMiddleware": []
+                    }
+                ],
+                "description": "Sets maintenance mode for the system",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Set maintenance mode",
+                "operationId": "set-maintenance-mode",
+                "parameters": [
+                    {
+                        "description": "Set Maintenance Mode Input",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/app.SetMaintenanceModeInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/user": {
             "get": {
                 "description": "Retrieves all data of the user",
@@ -1765,6 +1844,17 @@ const docTemplate = `{
                 },
                 "public_key": {
                     "type": "string"
+                }
+            }
+        },
+        "app.SetMaintenanceModeInput": {
+            "type": "object",
+            "required": [
+                "enabled"
+            ],
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
                 }
             }
         },

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -207,12 +207,12 @@ const docTemplate = `{
                 "operationId": "set-maintenance-mode",
                 "parameters": [
                     {
-                        "description": "Set Maintenance Mode Input",
+                        "description": "Maintenance Mode Status",
                         "name": "body",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/app.SetMaintenanceModeInput"
+                            "$ref": "#/definitions/app.MaintenanceModeStatus"
                         }
                     }
                 ],
@@ -1703,6 +1703,14 @@ const docTemplate = `{
                 }
             }
         },
+        "app.MaintenanceModeStatus": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "app.PendingRecordsResponse": {
             "type": "object",
             "properties": {
@@ -1844,17 +1852,6 @@ const docTemplate = `{
                 },
                 "public_key": {
                     "type": "string"
-                }
-            }
-        },
-        "app.SetMaintenanceModeInput": {
-            "type": "object",
-            "required": [
-                "enabled"
-            ],
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -200,12 +200,12 @@
                 "operationId": "set-maintenance-mode",
                 "parameters": [
                     {
-                        "description": "Set Maintenance Mode Input",
+                        "description": "Maintenance Mode Status",
                         "name": "body",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/app.SetMaintenanceModeInput"
+                            "$ref": "#/definitions/app.MaintenanceModeStatus"
                         }
                     }
                 ],
@@ -1696,6 +1696,14 @@
                 }
             }
         },
+        "app.MaintenanceModeStatus": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "app.PendingRecordsResponse": {
             "type": "object",
             "properties": {
@@ -1837,17 +1845,6 @@
                 },
                 "public_key": {
                     "type": "string"
-                }
-            }
-        },
-        "app.SetMaintenanceModeInput": {
-            "type": "object",
-            "required": [
-                "enabled"
-            ],
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -146,6 +146,85 @@
                 }
             }
         },
+        "/system/maintenance/status": {
+            "get": {
+                "security": [
+                    {
+                        "AdminMiddleware": []
+                    }
+                ],
+                "description": "Gets maintenance mode for the system",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Get maintenance mode",
+                "operationId": "get-maintenance-mode",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "AdminMiddleware": []
+                    }
+                ],
+                "description": "Sets maintenance mode for the system",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "Set maintenance mode",
+                "operationId": "set-maintenance-mode",
+                "parameters": [
+                    {
+                        "description": "Set Maintenance Mode Input",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/app.SetMaintenanceModeInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/app.APIResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/user": {
             "get": {
                 "description": "Retrieves all data of the user",
@@ -1758,6 +1837,17 @@
                 },
                 "public_key": {
                     "type": "string"
+                }
+            }
+        },
+        "app.SetMaintenanceModeInput": {
+            "type": "object",
+            "required": [
+                "enabled"
+            ],
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -142,6 +142,11 @@ definitions:
     - email
     - password
     type: object
+  app.MaintenanceModeStatus:
+    properties:
+      enabled:
+        type: boolean
+    type: object
   app.PendingRecordsResponse:
     properties:
       created_at:
@@ -237,13 +242,6 @@ definitions:
     required:
     - name
     - public_key
-    type: object
-  app.SetMaintenanceModeInput:
-    properties:
-      enabled:
-        type: boolean
-    required:
-    - enabled
     type: object
   app.UnreserveNodeResponse:
     properties:
@@ -526,12 +524,12 @@ paths:
       description: Sets maintenance mode for the system
       operationId: set-maintenance-mode
       parameters:
-      - description: Set Maintenance Mode Input
+      - description: Maintenance Mode Status
         in: body
         name: body
         required: true
         schema:
-          $ref: '#/definitions/app.SetMaintenanceModeInput'
+          $ref: '#/definitions/app.MaintenanceModeStatus'
       produces:
       - application/json
       responses:

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -238,6 +238,13 @@ definitions:
     - name
     - public_key
     type: object
+  app.SetMaintenanceModeInput:
+    properties:
+      enabled:
+        type: boolean
+    required:
+    - enabled
+    type: object
   app.UnreserveNodeResponse:
     properties:
       contract_id:
@@ -489,6 +496,56 @@ paths:
       security:
       - AdminMiddleware: []
       summary: List pending records
+      tags:
+      - admin
+  /system/maintenance/status:
+    get:
+      consumes:
+      - application/json
+      description: Gets maintenance mode for the system
+      operationId: get-maintenance-mode
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/app.APIResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/app.APIResponse'
+      security:
+      - AdminMiddleware: []
+      summary: Get maintenance mode
+      tags:
+      - admin
+    post:
+      consumes:
+      - application/json
+      description: Sets maintenance mode for the system
+      operationId: set-maintenance-mode
+      parameters:
+      - description: Set Maintenance Mode Input
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/app.SetMaintenanceModeInput'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/app.APIResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/app.APIResponse'
+      security:
+      - AdminMiddleware: []
+      summary: Set maintenance mode
       tags:
       - admin
   /user:

--- a/backend/internal/redis.go
+++ b/backend/internal/redis.go
@@ -251,6 +251,20 @@ func (r *RedisClient) HandleUnacknowledgedTasks(ctx context.Context, consumerNam
 	return nil
 }
 
+func (r *RedisClient) SetMaintenanceMode(ctx context.Context, enabled bool) error {
+	return r.client.Set(ctx, "maintenance_mode", enabled, 0).Err()
+}
+
+func (r *RedisClient) GetMaintenanceMode(ctx context.Context) (bool, error) {
+	res, err := r.client.Get(ctx, "maintenance_mode").Result()
+
+	if err != nil && err != redis.Nil {
+		return false, err
+	}
+
+	return res == "1", nil
+}
+
 func (r *RedisClient) Close() error {
 	return r.client.Close()
 }


### PR DESCRIPTION
### Description

allow to set the maintenance mode and store it 

### Changes

- add redis handlers to set and retrieve the maintenance status 

### Related Issues
- #89 

### Checklist

- [x] Tests included
- [x] Build pass
- [x] Documentation
- [x] Code format and docstring
