### PR TITLE
fix: prevent false success toast; refactor add-node flow

### DIFF
--- a/frontend/kubecloud/src/components/dashboard/EditClusterNodesDialog.vue
+++ b/frontend/kubecloud/src/components/dashboard/EditClusterNodesDialog.vue
@@ -141,7 +141,7 @@
       </template>
       <template #actions>
         <div v-if="editTab === 'add'" class="add-form-actions">
-          <v-btn variant="outlined" color="primary" :loading="addNodeLoading" :disabled="!canAssignToNode || addNodeLoading || !formValid" @click="confirmAddForm" class="mr-3">Add Node</v-btn>
+          <v-btn variant="outlined" color="primary" :loading="submitting" :disabled="!canAssignToNode || submitting || !formValid" @click="confirmAddForm" class="mr-3">Add Node</v-btn>
           <v-btn variant="outlined" @click="editTab = 'list'">Cancel</v-btn>
         </div>
       </template>
@@ -155,22 +155,17 @@ import { getAvailableCPU, getAvailableRAM, getAvailableStorage, getTotalCPU } fr
 import type { RentedNode } from '../../composables/useNodeManagement';
 import BaseDialogCard from './BaseDialogCard.vue';
 import { userService } from '../../utils/userService';
-import { useNotificationStore } from '../../stores/notifications';
-import {isAlphanumeric, required, min, max} from "../../utils/validation"
+import { isAlphanumeric, required, min, max } from "../../utils/validation"
 import { ROOTFS } from '../../composables/useDeployCluster';
-const notificationStore = useNotificationStore();
 const props = defineProps<{
   modelValue: boolean,
   cluster: any,
   nodes: any[],
   loading: boolean,
   availableNodes: RentedNode[],
-  addFormNode: RentedNode | undefined,
-  canAssignToNode: boolean,
-  addNodeLoading: boolean,
-  availableSshKeys: any[]
+  onAddNode: (payload: any) => Promise<void>
 }>();
-const emit = defineEmits(['update:modelValue', 'add-node', 'nodes-updated', 'remove-node']);
+const emit = defineEmits(['update:modelValue', 'nodes-updated', 'remove-node']);
 const dialog = computed({
   get: () => props.modelValue,
   set: (val: boolean) => emit('update:modelValue', val)
@@ -199,6 +194,7 @@ const sshKeys = ref<any[]>([]);
 const sshKeysLoading = ref(false);
 const sshKeysError = ref('');
 const formValid = ref(false);
+const submitting = ref(false);
 
 const validateNodeName = (value: string) :string|boolean =>  {
   const msg = required('Name is required')(value) || isAlphanumeric('Node name can only contain letters, and numbers.')(value);
@@ -253,27 +249,33 @@ watch([addFormNodeId, addFormRam, addFormStorage], () => {
     addFormNodeId.value=null;
   }
 });
-function confirmAddForm() {
+async function confirmAddForm() {
   // Find selected SSH key object
   const sshKeyObj = (sshKeys.value || []).find((k: any) => k.ID === addFormSshKey.value);
-  emit('add-node', {
+  const payload = {
     name: props.cluster.cluster.name,
-    token: '', // If you have a token, use it here
+    token: '',
     nodes: [
       {
         name: addFormName.value,
-        type: addFormRole.value, // 'master' | 'worker'
-        node_id: addFormNodeId.value, // backend expects node_id
+        type: addFormRole.value,
+        node_id: addFormNodeId.value,
         cpu: addFormCpu.value,
-        memory: addFormRam.value * 1024, // Convert GB to MB
-        root_size: ROOTFS * 1024, // MB
-        disk_size: addFormStorage.value * 1024, // Convert GB to MB
+        memory: addFormRam.value * 1024,
+        root_size: ROOTFS * 1024,
+        disk_size: addFormStorage.value * 1024,
         env_vars: sshKeyObj ? { SSH_KEY: sshKeyObj.public_key } : {},
       }
     ]
-  });
-  notificationStore.info('Deployment is being updated', 'Your node is being added in the background. You will be notified when it is ready.');
-  editTab.value = 'list';
+  };
+  try {
+    submitting.value = true;
+    await props.onAddNode(payload);
+    editTab.value = 'list';
+  } catch (e) {
+  } finally {
+    submitting.value = false;
+  }
 }
 // Filter available nodes based on form requirements and add 'name' property for v-select display
 const availableNodesWithName = computed(() =>

--- a/frontend/kubecloud/src/components/dashboard/ManageClusterView.vue
+++ b/frontend/kubecloud/src/components/dashboard/ManageClusterView.vue
@@ -138,12 +138,7 @@
       :nodes="filteredNodes"
       :loading="nodesLoading"
       :available-nodes="availableNodes"
-      :add-form-error="addFormError"
-      :add-form-node="addFormNode"
-      :can-assign-to-node="canAssignToNode"
-      :add-node-loading="addNodeLoading"
-      :available-ssh-keys="sshKeys"
-      @add-node="addNode"
+      :on-add-node="addNode"
       @remove-node="handleRemoveNode"
     />
   </div>
@@ -158,7 +153,7 @@ import { useNotificationStore } from '../../stores/notifications'
 import { useKubeconfig } from '../../composables/useKubeconfig'
 import { api } from '../../utils/api'
 
-import { getAvailableCPU, getAvailableRAM, getAvailableStorage } from '../../utils/nodeNormalizer'
+import { getAvailableRAM, getAvailableStorage } from '../../utils/nodeNormalizer'
 
 import { formatDate } from '../../utils/dateUtils'
 
@@ -289,35 +284,17 @@ const loadCluster = async () => {
 onMounted(loadCluster)
 watch(() => projectName.value, loadCluster)
 
-// Watch for cluster updates and refresh data when needed
-watch(() => clusterStore.clusters, (newClusters) => {
-  // Update editNodes if dialog is open
-  if (editClusterNodesDialog.value && cluster.value) {
-    const updatedCluster = newClusters.find(c => c.project_name === cluster.value?.project_name)
-    if (updatedCluster?.cluster?.nodes && Array.isArray(updatedCluster.cluster.nodes)) {
-      editNodes.value = updatedCluster.cluster.nodes.map((n: any) => ({ ...n }))
-    }
-  }
-}, { deep: true })
-
 const goBack = () => {
   router.push('/dashboard')
 }
 
 const editClusterNodesDialog = ref(false)
 
-// Dummy state for masters/workers (replace with real cluster data)
-const editNodes = ref<any[]>([])
-
 async function openEditClusterNodesDialog() {
-  const nodesRaw = cluster.value?.cluster?.nodes;
-  const nodes = Array.isArray(nodesRaw) ? nodesRaw : [];
-  editNodes.value = nodes.map(n => ({ ...n }));
   editClusterNodesDialog.value = true;
   await fetchRentedNodes();
 }
 
-const addNodeLoading = ref(false)
 const availableNodes = computed<RentedNode[]>(() => {
   return rentedNodes.value.filter((node: RentedNode) => {
     const availRAM = getAvailableRAM(node);
@@ -333,69 +310,19 @@ const notificationStore = useNotificationStore()
 
 // SSH keys state
 const sshKeys = ref<any[]>([])
-const addFormNodeId = ref(null);
-const addFormRole = ref('master');
-const addFormCpu = ref(1);
-const addFormRam = ref(1);
-const addFormStorage = ref(1);
-const addFormError = ref('');
-
-const addFormNode = computed<RentedNode | undefined>(() => availableNodes.value.find((n: RentedNode) => n.nodeId === addFormNodeId.value));
-
-const canAssignToNode = computed(() => {
-  const node = addFormNode.value;
-  if (!node) return false;
-  return (
-    addFormCpu.value > 0 &&
-    addFormRam.value > 0 &&
-    addFormStorage.value > 0 &&
-    addFormCpu.value <= getAvailableCPU(node) &&
-    addFormRam.value <= getAvailableRAM(node) &&
-    addFormStorage.value <= getAvailableStorage(node)
-  );
-});
-
-watch([addFormNodeId, addFormCpu, addFormRam, addFormStorage], () => {
-  const node = addFormNode.value;
-  if (!node) {
-    addFormError.value = '';
-    return;
-  }
-  if (
-    addFormCpu.value > getAvailableCPU(node) ||
-    addFormRam.value > getAvailableRAM(node) ||
-    addFormStorage.value > getAvailableStorage(node)
-  ) {
-    addFormError.value = 'Requested resources exceed available for the selected node.';
-  } else {
-    addFormError.value = '';
-  }
-});
 
 async function addNode(payload: any) {
-  // Accepts a cluster payload with a nodes array
   if (!payload || !payload.name || !Array.isArray(payload.nodes) || payload.nodes.length === 0) {
-    addFormError.value = 'Invalid node payload.';
     notificationStore.error('Add Node Error', 'Invalid node payload.');
-    return;
+    throw new Error('Invalid node payload.');
   }
-  addNodeLoading.value = true;
-  addFormError.value = '';
   try {
     await addNodeToDeployment(payload.name, payload);
-
-    // Reset add form state
-    addFormNodeId.value = null;
-    addFormRole.value = 'master';
-    addFormCpu.value = 1;
-    addFormRam.value = 1;
-    addFormStorage.value = 1;
+    notificationStore.info('Deployment is being updated', 'Your node is being added in the background. You will be notified when it is ready.');
   } catch (e: any) {
     const errorMessage = e?.message || 'Failed to add node';
-    addFormError.value = errorMessage;
     notificationStore.error('Add Node Failed', errorMessage);
-  } finally {
-    addNodeLoading.value = false;
+    throw e;
   }
 }
 

--- a/frontend/kubecloud/src/components/dashboard/ManageClusterView.vue
+++ b/frontend/kubecloud/src/components/dashboard/ManageClusterView.vue
@@ -311,7 +311,6 @@ const notificationStore = useNotificationStore()
 async function addNode(payload: any) {
   if (!payload || !payload.name || !Array.isArray(payload.nodes) || payload.nodes.length === 0) {
     notificationStore.error('Add Node Error', 'Invalid node payload.');
-    throw new Error('Invalid node payload.');
   }
   try {
     await addNodeToDeployment(payload.name, payload);

--- a/frontend/kubecloud/src/components/dashboard/ManageClusterView.vue
+++ b/frontend/kubecloud/src/components/dashboard/ManageClusterView.vue
@@ -308,9 +308,6 @@ const { rentedNodes, loading: nodesLoading, fetchRentedNodes, addNodeToDeploymen
 // Notification store
 const notificationStore = useNotificationStore()
 
-// SSH keys state
-const sshKeys = ref<any[]>([])
-
 async function addNode(payload: any) {
   if (!payload || !payload.name || !Array.isArray(payload.nodes) || payload.nodes.length === 0) {
     notificationStore.error('Add Node Error', 'Invalid node payload.');
@@ -320,9 +317,6 @@ async function addNode(payload: any) {
     await addNodeToDeployment(payload.name, payload);
     notificationStore.info('Deployment is being updated', 'Your node is being added in the background. You will be notified when it is ready.');
   } catch (e: any) {
-    const errorMessage = e?.message || 'Failed to add node';
-    notificationStore.error('Add Node Failed', errorMessage);
-    throw e;
   }
 }
 

--- a/frontend/kubecloud/src/components/dashboard/ManageClusterView.vue
+++ b/frontend/kubecloud/src/components/dashboard/ManageClusterView.vue
@@ -317,6 +317,7 @@ async function addNode(payload: any) {
     await addNodeToDeployment(payload.name, payload);
     notificationStore.info('Deployment is being updated', 'Your node is being added in the background. You will be notified when it is ready.');
   } catch (e: any) {
+    console.error(e);
   }
 }
 


### PR DESCRIPTION
### Changes

- Move success notification to parent after successful API resolve
- Pass function prop onAddNode from parent; child awaits it and manages local submitting
- Remove premature success toast and tab switch from child
- Drop unused props/state: addNodeLoading, addFormError, addFormNode, canAssignToNode, availableSshKeys
- Simplify parent: remove add-form watchers/state; keep only availableNodes and sshKeys
- Clean imports and unused code
- Disable Add button during submission and only switch to list tab on success

### Related Issues

- https://github.com/codescalers/kubecloud/issues/202
