### PR TITLE
Update manage cluster view 

### DIFF
--- a/frontend/kubecloud/src/components/dashboard/ClustersCard.vue
+++ b/frontend/kubecloud/src/components/dashboard/ClustersCard.vue
@@ -84,21 +84,20 @@
               </v-tooltip>
               <v-tooltip location="top">
                 <template #activator="{ props }">
-                  <v-btn icon size="small" class="mr-1" v-bind="props" @click="openAddNodeDialog(cluster)" :disabled="deletingAll">
-                    <v-icon icon="mdi-pencil" />
-                  </v-btn>
-                </template>
-                <span>Add node</span>
-              </v-tooltip>
-              <v-tooltip location="top">
-                <template #activator="{ props }">
                   <v-btn icon size="small" class="mr-1" v-bind="props" @click="download(cluster.cluster.name)" :loading="downloading === cluster.cluster.name" :disabled="downloading === cluster.cluster.name || deletingAll">
                     <v-icon icon="mdi-download" />
                   </v-btn>
                 </template>
                 <span>Download kubeconfig file</span>
               </v-tooltip>
-
+              <v-tooltip location="top">
+                <template #activator="{ props }">
+                  <v-btn icon size="small" class="mr-1" v-bind="props" @click="openAddNodeDialog(cluster)" :disabled="deletingAll">
+                    <v-icon icon="mdi-server-plus" />
+                  </v-btn>
+                </template>
+                <span>Add node</span>
+              </v-tooltip>
               <v-tooltip location="top">
                 <template #activator="{ props }">
                   <v-btn icon size="small" class="ml-1" color="error" v-bind="props" @click="deleteCluster(cluster.cluster.name)" :disabled="deletingAll">
@@ -246,9 +245,11 @@ const paginatedClusters = computed(() => {
   return filteredClusters.value.slice(start, start + pageSize)
 })
 
+
 const viewCluster = (projectName: string) => {
   router.push(`/clusters/${projectName}`)
 }
+
 
 function deleteCluster(projectName: string) {
   clusterToDelete.value = projectName

--- a/frontend/kubecloud/src/components/dashboard/ClustersCard.vue
+++ b/frontend/kubecloud/src/components/dashboard/ClustersCard.vue
@@ -93,7 +93,7 @@
               <v-tooltip location="top">
                 <template #activator="{ props }">
                   <v-btn icon size="small" class="mr-1" v-bind="props" @click="openAddNodeDialog(cluster)" :disabled="deletingAll">
-                    <v-icon icon="mdi-server-plus" />
+                    <v-icon icon="mdi-plus" />
                   </v-btn>
                 </template>
                 <span>Add node</span>

--- a/frontend/kubecloud/src/components/dashboard/ClustersCard.vue
+++ b/frontend/kubecloud/src/components/dashboard/ClustersCard.vue
@@ -76,21 +76,20 @@
             <td>
               <v-tooltip location="top">
                 <template #activator="{ props }">
-                  <v-btn icon size="small" class="mr-1" v-bind="props" @click="openAddNodeDialog(cluster)" :disabled="deletingAll">
-                    <v-icon icon="mdi-pencil" />
-                  </v-btn>
-                </template>
-                <span>Add node</span>
-              </v-tooltip>
-              <v-tooltip location="top">
-                <template #activator="{ props }">
                   <v-btn icon size="small" class="mr-1" v-bind="props" @click="viewCluster(cluster.cluster.name)" :disabled="deletingAll">
                     <v-icon icon="mdi-eye" />
                   </v-btn>
                 </template>
                 <span>View cluster</span>
               </v-tooltip>
-
+              <v-tooltip location="top">
+                <template #activator="{ props }">
+                  <v-btn icon size="small" class="mr-1" v-bind="props" @click="openAddNodeDialog(cluster)" :disabled="deletingAll">
+                    <v-icon icon="mdi-pencil" />
+                  </v-btn>
+                </template>
+                <span>Add node</span>
+              </v-tooltip>
               <v-tooltip location="top">
                 <template #activator="{ props }">
                   <v-btn icon size="small" class="mr-1" v-bind="props" @click="download(cluster.cluster.name)" :loading="downloading === cluster.cluster.name" :disabled="downloading === cluster.cluster.name || deletingAll">
@@ -247,11 +246,9 @@ const paginatedClusters = computed(() => {
   return filteredClusters.value.slice(start, start + pageSize)
 })
 
-
 const viewCluster = (projectName: string) => {
   router.push(`/clusters/${projectName}`)
 }
-
 
 function deleteCluster(projectName: string) {
   clusterToDelete.value = projectName

--- a/frontend/kubecloud/src/components/dashboard/ClustersCard.vue
+++ b/frontend/kubecloud/src/components/dashboard/ClustersCard.vue
@@ -76,11 +76,19 @@
             <td>
               <v-tooltip location="top">
                 <template #activator="{ props }">
-                  <v-btn icon size="small" class="mr-1" v-bind="props" @click="viewCluster(cluster.cluster.name)" :disabled="deletingAll">
-                    <v-icon icon="mdi-cog" />
+                  <v-btn icon size="small" class="mr-1" v-bind="props" @click="openAddNodeDialog(cluster)" :disabled="deletingAll">
+                    <v-icon icon="mdi-pencil" />
                   </v-btn>
                 </template>
-                <span>Edit cluster</span>
+                <span>Add node</span>
+              </v-tooltip>
+              <v-tooltip location="top">
+                <template #activator="{ props }">
+                  <v-btn icon size="small" class="mr-1" v-bind="props" @click="viewCluster(cluster.cluster.name)" :disabled="deletingAll">
+                    <v-icon icon="mdi-eye" />
+                  </v-btn>
+                </template>
+                <span>View cluster</span>
               </v-tooltip>
 
               <v-tooltip location="top">
@@ -145,17 +153,26 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
+
+    <!-- Edit Cluster Nodes Modal -->
+    <component :is="EditClusterNodesDialog"
+      v-if="selectedCluster"
+      v-model="editClusterNodesDialog"
+      :cluster="selectedCluster"
+      @update:modelValue="editClusterNodesDialog = $event"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch, nextTick } from 'vue'
+import { ref, computed, onMounted, watch, nextTick, defineAsyncComponent } from 'vue'
 import { useRouter } from 'vue-router'
 import { useClusterStore } from '../../stores/clusters'
 import { useNotificationStore } from '../../stores/notifications'
 import { useKubeconfig } from '../../composables/useKubeconfig'
-import { useNodeManagement } from '@/composables/useNodeManagement'
 import { useUserStore } from '@/stores/user'
+
+const EditClusterNodesDialog = defineAsyncComponent(() => import('./EditClusterNodesDialog.vue'))
 
 const router = useRouter()
 const clusterStore = useClusterStore()
@@ -168,6 +185,14 @@ const deletingAll = ref(false)
 
 const emit = defineEmits(['navigateToFund'])
 const { download, downloading } = useKubeconfig()
+
+const editClusterNodesDialog = ref(false)
+const selectedCluster = ref<any>(null)
+
+const openAddNodeDialog = (cluster: any) => {
+  selectedCluster.value = cluster
+  editClusterNodesDialog.value = true
+}
 
 const search = ref('')
 const sortBy = ref('createdAt')
@@ -222,9 +247,11 @@ const paginatedClusters = computed(() => {
   return filteredClusters.value.slice(start, start + pageSize)
 })
 
+
 const viewCluster = (projectName: string) => {
   router.push(`/clusters/${projectName}`)
 }
+
 
 function deleteCluster(projectName: string) {
   clusterToDelete.value = projectName

--- a/frontend/kubecloud/src/components/dashboard/EditClusterNodesDialog.vue
+++ b/frontend/kubecloud/src/components/dashboard/EditClusterNodesDialog.vue
@@ -1,59 +1,23 @@
 <template>
-  <div>
-    <v-dialog v-model="dialog" max-width="900">
+    <v-dialog v-model="props.modelValue" max-width="900">
       <BaseDialogCard>
         <template #title>
-          Edit Cluster Nodes
+          Add Node
         </template>
         <template #content>
-          <v-tabs v-model="editTab" class="mb-4">
-            <v-tab value="list">Node List</v-tab>
-            <v-tab value="add">Add Node</v-tab>
-          </v-tabs>
-          <div v-if="editTab === 'list'">
-            <v-table v-if="editNodesWithStorage.length">
-              <thead>
-                <tr>
-                  <th>Name</th>
-                  <th>Type</th>
-                  <th>CPU</th>
-                  <th>RAM</th>
-                  <th>Storage</th>
-                  <th>IP</th>
-                  <th>Contract ID</th>
-                  <th>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr v-for="node in editNodesWithStorage" :key="node.name">
-                  <td>{{ node.original_name }}</td>
-                  <td>{{ node.type }}</td>
-                  <td>{{ node.cpu }}</td>
-                  <td>{{ Math.round((node.memory ?? node.ram) / 1024) }} GB</td>
-                  <td>{{ node.storage }} GB</td>
-                  <td>{{ node.ip || '-' }}</td>
-                  <td>{{ node.contract_id || '-' }}</td>
-                  <td>
-                    <v-btn @click="showDeleteConfirmation(node.original_name)" :disabled='node.type == "leader"'><v-icon>mdi-delete</v-icon></v-btn>
-                  </td>
-                </tr>
-              </tbody>
-            </v-table>
-            <div v-else class="empty-list">No nodes in this cluster.</div>
-          </div>
-          <div v-else-if="editTab === 'add'">
-            <v-form  v-model="formValid">
+          <div>
+            <v-form ref="form"  v-model="formValid">
               <div class="add-form-wrapper">
-                <v-text-field 
-                  validate-on="eager" 
-                  :rules="[RULES.nodeName]" 
-                  v-model="addFormName" 
-                  label="Name" 
+                <v-text-field
+                  :rules="[RULES.nodeName]"
+                  v-model="addFormName"
+                  label="Name"
                 />
                 <v-text-field validate-on="eager" :rules="[RULES.cpu]" v-model.number="addFormCpu" label="CPU" type="number" min="1" />
                 <v-text-field validate-on="eager" :rules="[RULES.ram]" v-model.number="addFormRam" label="RAM (GB)" type="number" min="1" />
                 <v-text-field validate-on="eager" :rules="[RULES.storage]" v-model.number="addFormStorage" label="Storage (GB)" type="number" min="1" />
-              <NodeSelect
+                <NodeSelect
+                :loading="nodesLoading"
                 v-model="addFormNodeId"
                 :items="availableNodesWithName"
                 label="Select Node"
@@ -93,39 +57,17 @@
           </div>
         </template>
         <template #actions>
-          <div v-if="editTab === 'add'" class="add-form-actions">
+          <div >
             <v-btn variant="outlined" color="primary" :loading="submitting" :disabled="!canAssignToNode || submitting || !formValid" @click="confirmAddForm" class="mr-3">Add Node</v-btn>
-            <v-btn variant="outlined" @click="dialog = false">Cancel</v-btn>
+            <v-btn variant="outlined" @click="emit('update:modelValue', false)">Cancel</v-btn>
           </div>
         </template>
       </BaseDialogCard>
     </v-dialog>
-
-    <!-- Delete Confirmation Dialog -->
-    <v-dialog v-model="deleteConfirmDialog" max-width="400">
-      <v-card>
-        <v-card-title class="text-h6">
-          Confirm Node Deletion
-        </v-card-title>
-        <v-card-text>
-          Are you sure you want to delete the node <strong>{{ nodeToDelete }}</strong>? This action cannot be undone.
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer></v-spacer>
-          <v-btn color="grey" variant="text" @click="deleteConfirmDialog = false">
-            Cancel
-          </v-btn>
-          <v-btn color="error" variant="text" @click="confirmDeleteNode">
-            Delete
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-  </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onMounted } from 'vue';
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue';
 import { getAvailableCPU, getAvailableRAM, getAvailableStorage, getTotalCPU } from '../../utils/nodeNormalizer';
 import type { RawNode } from '../../types/rawNode';
 import BaseDialogCard from './BaseDialogCard.vue';
@@ -133,45 +75,37 @@ import { userService } from '../../utils/userService';
 import { ROOTFS } from '../../composables/useDeployCluster';
 import NodeSelect from '../ui/NodeSelect.vue';
 import { RULES } from "../../utils/validation";
+import { useNodes } from '../../composables/useNodes';
+import { useNotificationStore } from '../../stores/notifications';
 
 const props = defineProps<{
   modelValue: boolean,
-  cluster: any,
-  nodes: any[],
-  loading: boolean,
-  availableNodes: RawNode[],
-  onAddNode: (payload: any) => Promise<void>
+  cluster: any
 }>();
 const emit = defineEmits(['update:modelValue', 'nodes-updated', 'remove-node']);
-const dialog = computed({
-  get: () => props.modelValue,
-  set: (val: boolean) => emit('update:modelValue', val)
-});
-const editTab = ref('list');
-const editNodes = ref<any[]>(props.nodes || []);
-watch(() => props.nodes, (val) => { editNodes.value = val || []; });
+
+// Initialize composables
+const { nodes, loading: nodesLoading, fetchNodes } = useNodes()
+const notificationStore = useNotificationStore()
+
+
+const clusterNodes = computed(() => {
+  if (!props.cluster?.cluster?.nodes) return []
+  if (Array.isArray(props.cluster.cluster.nodes)) {
+    return props.cluster.cluster.nodes.filter((node: any) => typeof node === 'object' && node !== null)
+  }
+  return []
+})
+
+const editNodes = ref<any[]>([])
+watch(() => clusterNodes.value, (val) => { editNodes.value = val || [] }, { immediate: true })
 const editNodesWithStorage = computed(() =>
   (editNodes.value || []).map(node => ({
     ...node,
     storage: Math.round(((node.root_size || 0) + (node.disk_size || 0) + (node.storage || 0)) / 1024)
   }))
 );
-function removeNode(nodeName: string) {
-  emit('remove-node', nodeName);
-}
 
-function showDeleteConfirmation(nodeName: string) {
-  nodeToDelete.value = nodeName;
-  deleteConfirmDialog.value = true;
-}
-
-function confirmDeleteNode() {
-  if (nodeToDelete.value) {
-    removeNode(nodeToDelete.value);
-    deleteConfirmDialog.value = false;
-    nodeToDelete.value = '';
-  }
-}
 // Add node form state
 const addFormNodeId = ref<number|null>(null);
 const addFormRole = ref('master');
@@ -185,14 +119,62 @@ const sshKeysLoading = ref(false);
 const sshKeysError = ref('');
 const formValid = ref(false);
 const submitting = ref(false);
+const form = ref<any>(null)
 
 // Delete confirmation dialog state
 const deleteConfirmDialog = ref(false);
 const nodeToDelete = ref<string>('');
 
+// Node management functions
+async function addNodeToDeployment(deploymentName: string, clusterPayload: { name: string, nodes: any[] }) {
+  return await userService.addNodeToDeployment(deploymentName, clusterPayload)
+}
+
+
+async function handleAddNode(payload: any) {
+  if (!payload || !payload.name || !Array.isArray(payload.nodes) || payload.nodes.length === 0) {
+    notificationStore.error('Add Node Error', 'Invalid node payload.')
+    return
+  }
+  try {
+    await addNodeToDeployment(payload.name, payload)
+    notificationStore.info('Deployment is being updated', 'Your node is being added in the background. You will be notified when it is ready.')
+    emit('update:modelValue', false) // Close dialog on success
+  } catch (e: any) {
+    console.error(e)
+    notificationStore.error('Add Node Failed', e?.message || 'Failed to add node')
+  }
+}
+
+
+function handleClose() {
+  resetForm()
+  emit('update:modelValue', false)
+
+}
+
+// Reset form fields to default values
+function resetForm() {
+  form.value?.reset()
+  addFormRole.value = 'master'
+  addFormCpu.value = 2
+  addFormRam.value = 4
+  addFormStorage.value = 25
+  addFormSshKeys.value = sshKeys.value.length > 0 ? [sshKeys.value[0].ID] : []
+}
+
+watch(() => props.modelValue, async (isOpen) => {
+  if (isOpen) {
+    await fetchNodes()
+  } else {
+    resetForm()
+  }
+})
+
 onMounted(async () => {
   sshKeysLoading.value = true;
   try {
+    await fetchNodes()
     sshKeys.value = await userService.listSshKeys();
     if (sshKeys.value.length > 0) {
       addFormSshKeys.value = [sshKeys.value[0].ID];
@@ -203,7 +185,16 @@ onMounted(async () => {
     sshKeysLoading.value = false;
   }
 });
-const addFormNode = computed<RawNode | undefined>(() => (props.availableNodes || []).find((n: RawNode) => n.nodeId === addFormNodeId.value));
+// Available nodes computation
+const availableNodes = computed<RawNode[]>(() => {
+  return nodes.value.filter((node: RawNode) => {
+    const availRAM = getAvailableRAM(node)
+    const availStorage = getAvailableStorage(node)
+    return availRAM > 0 && availStorage > 0
+  })
+})
+
+const addFormNode = computed<RawNode | undefined>(() => availableNodes.value.find((n: RawNode) => n.nodeId === addFormNodeId.value));
 const canAssignToNode = computed(() => {
   const node = addFormNode.value;
   if (!node) return false;
@@ -251,8 +242,7 @@ async function confirmAddForm() {
   };
   try {
     submitting.value = true;
-    await props.onAddNode(payload);
-    editTab.value = 'list';
+    await handleAddNode(payload);
   } catch (e) {
   } finally {
     submitting.value = false;
@@ -260,7 +250,7 @@ async function confirmAddForm() {
 }
 // Filter available nodes based on form requirements and add 'name' property for v-select display
 const availableNodesWithName = computed(() =>
-  (props.availableNodes || [])
+  availableNodes.value
     .filter(node => {
       // Only show nodes that have sufficient available resources
       const availableRAM = getAvailableRAM(node);

--- a/frontend/kubecloud/src/components/dashboard/ManageClusterView.vue
+++ b/frontend/kubecloud/src/components/dashboard/ManageClusterView.vue
@@ -458,23 +458,6 @@ const notificationStore = useNotificationStore()
   text-align: center;
   margin: 2rem 0;
 }
-
-.selectable-row {
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-}
-
-.selectable-row:hover {
-  background-color: rgba(255, 255, 255, 0.05);
-}
-
-.selected-row {
-  background-color: rgba(var(--v-theme-primary), 0.1);
-}
-
-.selected-row:hover {
-  background-color: rgba(var(--v-theme-primary), 0.15);
-}
 .header-top {
   display: flex;
   align-items: center;

--- a/frontend/kubecloud/src/components/dashboard/ManageClusterView.vue
+++ b/frontend/kubecloud/src/components/dashboard/ManageClusterView.vue
@@ -29,14 +29,14 @@
             </v-btn>
             <v-btn variant="outlined" class="btn btn-outline" @click="openEditClusterNodesDialog">
               <v-icon icon="mdi-pencil" class="mr-2"></v-icon>
-              Edit Cluster
+              Add Node
             </v-btn>
             <v-btn variant="outlined" class="btn btn-outline" color="error" @click="openDeleteModal">
               <v-icon icon="mdi-delete" class="mr-2"></v-icon>
               Delete
             </v-btn>
           </div>
-          <div class="main-content-card modern-cluster-card">
+          <div class="main-content- modern-cluster-card">
             <div class="modern-cluster-info">
               <div class="cluster-info-grid">
                 <div class="info-label">Project Name</div>
@@ -71,10 +71,12 @@
                     <th>Mycelium IP</th>
                     <th>Planetary IP</th>
                     <th>Contract ID</th>
+                    <th>Actions</th>
                   </tr>
                 </thead>
                 <tbody>
                   <tr v-for="node in filteredNodes" :key="node.node_id">
+
                     <td>{{ node.original_name }}</td>
                     <td>{{ node.type }}</td>
                     <td>{{ node.cpu }}</td>
@@ -103,6 +105,22 @@
                       <span v-else>-</span>
                     </td>
                     <td>{{ node.contract_id || '-' }}</td>
+                    <td>
+                      <v-btn
+                        icon
+                        size="small"
+                        color="error"
+                        variant="text"
+                        @click="showDeleteConfirmation(node.original_name)"
+                        :disabled="node.type === 'leader'"
+                        class="delete-node-btn"
+                      >
+                        <v-icon icon="mdi-delete" size="small" />
+                        <v-tooltip activator="parent" location="top">
+                          Delete Node
+                        </v-tooltip>
+                      </v-btn>
+                    </td>
                   </tr>
                 </tbody>
               </v-table>
@@ -113,6 +131,27 @@
       </v-container>
     </div>
 
+
+    <!-- Delete Confirmation Dialog -->
+    <v-dialog v-model="deleteConfirmDialog" max-width="400">
+      <v-card>
+        <v-card-title class="text-h6">
+          Confirm Node Deletion
+        </v-card-title>
+        <v-card-text>
+          Are you sure you want to delete the node <strong>{{ nodeToDelete }}</strong>? This action cannot be undone.
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="grey" variant="text" @click="deleteConfirmDialog = false">
+            Cancel
+          </v-btn>
+          <v-btn color="error" variant="text" @click="confirmDeleteNode">
+            Delete
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
     <!-- Kubeconfig Modal -->
     <component :is="KubeconfigDialog"
       v-model="kubeconfigDialog"
@@ -133,14 +172,9 @@
 
     <!-- Edit Cluster Nodes Modal -->
     <component :is="EditClusterNodesDialog"
-      :key="editClusterNodesDialog ? 'open' : 'closed'"
       v-model="editClusterNodesDialog"
       :cluster="cluster"
-      :nodes="filteredNodes"
-      :loading="nodesLoading"
-      :available-nodes="availableNodes"
-      :on-add-node="addNode"
-      @remove-node="handleRemoveNode"
+      @update:modelValue="editClusterNodesDialog = $event"
     />
   </div>
 </template>
@@ -149,16 +183,12 @@
 import { ref, computed, onMounted, watch, defineAsyncComponent } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useClusterStore } from '../../stores/clusters'
-import { useNodes } from '../../composables/useNodes'
-import type { RawNode } from '../../types/rawNode'
 import { useNotificationStore } from '../../stores/notifications'
 import { useKubeconfig } from '../../composables/useKubeconfig'
 import { api } from '../../utils/api'
-import { userService } from '../../utils/userService'
-
-import { getAvailableRAM, getAvailableStorage } from '../../utils/nodeNormalizer'
 
 import { formatDate } from '../../utils/dateUtils'
+import { userService } from '@/utils/userService'
 
 // Import dialogs
 const EditClusterNodesDialog = defineAsyncComponent(() => import('./EditClusterNodesDialog.vue'))
@@ -171,6 +201,8 @@ const clusterStore = useClusterStore()
 
 const loading = ref(true)
 const notFound = ref(false)
+const deleteConfirmDialog = ref(false);
+const nodeToDelete = ref<string>('');
 
 const projectName = computed(() => route.params.id?.toString() || '')
 const cluster = computed(() =>
@@ -212,8 +244,8 @@ async function showKubeconfig() {
   kubeconfigError.value = ''
   kubeconfigContent.value = ''
   try {
-    const response = await api.get(`/v1/deployments/${projectName.value}/kubeconfig`, { 
-      requiresAuth: true, 
+    const response = await api.get(`/v1/deployments/${projectName.value}/kubeconfig`, {
+      requiresAuth: true,
       showNotifications: false,
       timeout: 120000
     })
@@ -285,6 +317,11 @@ const loadCluster = async () => {
 }
 
 onMounted(loadCluster)
+const emit = defineEmits(['update:modelValue', 'nodes-updated', 'remove-node']);
+function showDeleteConfirmation(nodeName: string) {
+  nodeToDelete.value = nodeName;
+  deleteConfirmDialog.value = true;
+}
 watch(() => projectName.value, loadCluster)
 
 const goBack = () => {
@@ -294,54 +331,34 @@ const goBack = () => {
 const editClusterNodesDialog = ref(false)
 
 async function openEditClusterNodesDialog() {
-  editClusterNodesDialog.value = true;
-  await fetchNodes();
+  editClusterNodesDialog.value = true
 }
 
-const availableNodes = computed<RawNode[]>(() => {
-  return nodes.value.filter((node: RawNode) => {
-    const availRAM = getAvailableRAM(node);
-    const availStorage = getAvailableStorage(node);
-    return availRAM > 0 && availStorage > 0;
-  });
-});
+const deletingNodeId = ref<string | null>(null)
 
-const { nodes, loading: nodesLoading, fetchNodes, getNodeType } = useNodes()
 
-// Node management functions
-async function addNodeToDeployment(deploymentName: string, clusterPayload: { name: string, nodes: any[] }) {
-  return await userService.addNodeToDeployment(deploymentName, clusterPayload)
+function confirmDeleteNode() {
+  if (nodeToDelete.value) {
+    handleRemoveNode(nodeToDelete.value);
+    deleteConfirmDialog.value = false;
+    nodeToDelete.value = '';
+  }
+}
+async function handleRemoveNode(nodeName: string) {
+  try {
+    await removeNodeFromDeployment(cluster.value?.cluster?.name || '', nodeName)
+    notificationStore.info('Node Removal Started', 'Node is being removed from the cluster in the background. You will be notified when the operation completes.')
+  } catch (e: any) {
+    const errorMessage = e?.message || 'Failed to remove node'
+    notificationStore.error('Remove Node Failed', errorMessage)
+  }
 }
 
 async function removeNodeFromDeployment(deploymentName: string, nodeName: string) {
   return await userService.removeNodeFromDeployment(deploymentName, nodeName)
 }
 
-// Notification store
 const notificationStore = useNotificationStore()
-
-async function addNode(payload: any) {
-  if (!payload || !payload.name || !Array.isArray(payload.nodes) || payload.nodes.length === 0) {
-    notificationStore.error('Add Node Error', 'Invalid node payload.');
-  }
-  try {
-    await addNodeToDeployment(payload.name, payload);
-    notificationStore.info('Deployment is being updated', 'Your node is being added in the background. You will be notified when it is ready.');
-  } catch (e: any) {
-    console.error(e);
-  }
-}
-
-async function handleRemoveNode(nodeName: string) {
-  if (!cluster.value?.cluster?.name) return;
-  try {
-    await removeNodeFromDeployment(cluster.value.cluster.name, nodeName);
-    notificationStore.info('Node Removal Started', `Node is being removed from the cluster in the background. You will be notified when the operation completes.`);
-  } catch (e: any) {
-    const errorMessage = e?.message || 'Failed to remove node';
-    notificationStore.error('Remove Node Failed', errorMessage);
-  }
-}
 
 </script>
 
@@ -367,6 +384,7 @@ async function handleRemoveNode(nodeName: string) {
   margin: 0;
 }
 .status-actions {
+  padding: 2.5rem 2.5rem 2rem 2.5rem !important;
   display: flex;
   gap: var(--space-3);
 }
@@ -377,13 +395,12 @@ async function handleRemoveNode(nodeName: string) {
   margin-bottom: var(--space-4);
 }
 .main-content-card {
-  padding: unset !important;
   overflow: hidden;
 }
 .modern-cluster-card {
   background: rgba(255,255,255,0.03);
   border-radius: 0.25rem;
-  padding: 2.5rem 2.5rem 2rem 2.5rem !important;
+  padding: 1.5rem 1.5rem 1rem 1.5rem !important;
 }
 .modern-cluster-info {
   display: flex;
@@ -440,6 +457,23 @@ async function handleRemoveNode(nodeName: string) {
   color: var(--color-text-muted);
   text-align: center;
   margin: 2rem 0;
+}
+
+.selectable-row {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.selectable-row:hover {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.selected-row {
+  background-color: rgba(var(--v-theme-primary), 0.1);
+}
+
+.selected-row:hover {
+  background-color: rgba(var(--v-theme-primary), 0.15);
 }
 .header-top {
   display: flex;

--- a/frontend/kubecloud/src/composables/useNodes.ts
+++ b/frontend/kubecloud/src/composables/useNodes.ts
@@ -30,6 +30,7 @@ export function useNodes() {
 
   // Fetch all available nodes (both reserved and shared)
   async function fetchNodes(nodeFilters?: NodeFilters) {
+    nodes.value = []
     loading.value = true
     error.value = null
     try {
@@ -98,15 +99,15 @@ export function useNodes() {
   const normalizedNodes = computed<NormalizedNode[]>(() => nodes.value.map(normalizeNode))
 
   // Computed properties to categorize nodes
-  const reservedNodes = computed<RawNode[]>(() => 
+  const reservedNodes = computed<RawNode[]>(() =>
     nodes.value.filter(node => node.rented && node.rentedByTwinId)
   )
 
-  const sharedNodes = computed<RawNode[]>(() => 
+  const sharedNodes = computed<RawNode[]>(() =>
     nodes.value.filter(node => !node.rented && node.rentable)
   )
 
-  const availableNodes = computed<RawNode[]>(() => 
+  const availableNodes = computed<RawNode[]>(() =>
     nodes.value.filter(node => node.rentable || (node.rented && node.rentedByTwinId))
   )
 


### PR DESCRIPTION
### Description

This is about changing the way of listing, adding, and deleting cluster nodes from UI 

<img width="1280" height="617" alt="image" src="https://github.com/user-attachments/assets/23c32819-2842-4dc0-a31d-77d025a8ac8b" />
<img width="1061" height="624" alt="image" src="https://github.com/user-attachments/assets/d7cc84eb-3c82-4bb0-b2fa-26676540d9cf" />

### Changes

- clusters view: add view cluster and add node buttons
- manage cluster: add a delete button to delete nodes from the table directly
- edit node dialog: remove list tab and only make it for adding nodes
- Use nodes: reset the nodes before fetching the nodes
### Related Issues

- #392 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstring
