### PR TITLE
Enhance insufficient balance flow 

### DIFF
--- a/frontend/kubecloud/src/components/dashboard/ClustersCard.vue
+++ b/frontend/kubecloud/src/components/dashboard/ClustersCard.vue
@@ -5,10 +5,17 @@
         <h3 class="text-h5 font-weight-bold mb-1">Kubernetes Clusters</h3>
         <p class="text-body-2 text-medium-emphasis">Manage your cloud-native infrastructure</p>
       </div>
-      <v-btn :disabled="isLoading || !haveEnoughBalance"  variant="outlined" class="mr-2" @click="goToDeployCluster">
-        <v-icon icon="mdi-plus" size="16" class="mr-1"></v-icon>
-        New Cluster
-      </v-btn>
+      <v-tooltip location="top" :disabled="haveEnoughBalance">
+        <template #activator="{ props }">
+          <div v-bind="props">
+            <v-btn :disabled="isLoading || !haveEnoughBalance"  variant="outlined" class="mr-2" @click="goToDeployCluster">
+              <v-icon icon="mdi-plus" size="16" class="mr-1"></v-icon>
+              New Cluster
+            </v-btn>
+          </div>
+        </template>
+        <span>Insufficient balance. Minimum 5 TFT required to create a cluster.</span>
+      </v-tooltip>
       <v-btn
         v-if="filteredClusters.length > 0 && !isLoading"
         variant="outlined"
@@ -41,7 +48,7 @@
       <v-divider class="mb-4" />
       <v-alert v-if="error" type="error" class="mb-4">{{ error }}</v-alert>
       <v-progress-linear v-if="isLoading" indeterminate color="primary" class="mb-4" />
-      <div v-else-if="!haveEnoughBalance" class="text-center text-medium-emphasis mt-12">
+      <div v-else-if="!haveEnoughBalance && !isLoading && filteredClusters.length === 0" class="text-center text-medium-emphasis mt-12">
         <v-icon icon="mdi-currency-usd-off" size="48" class="mb-2" color="grey" />
         <div>You don't have enough balance to create a cluster <br/> You must have at least <span class="text-primary">$5</span> to create a cluster</div>
         <v-btn variant="outlined" class="btn btn-outline mt-3" @click="goToFund">
@@ -203,11 +210,11 @@ const sortOptions = [
   { value: 'nodes', title: 'Nodes' },
 ]
 
-const userStore = useUserStore()
+  const userStore = useUserStore()
 
-const haveEnoughBalance = computed(() => {
-  return userStore.netBalance >= 5
-})
+  const haveEnoughBalance = computed(() => {
+    return userStore.netBalance >= 5
+  })
 
 const error = computed(() => clusterStore.error)
 const isLoading = computed(() => clusterStore.isLoading || userStore.isLoading)

--- a/frontend/kubecloud/src/components/dashboard/ManageClusterView.vue
+++ b/frontend/kubecloud/src/components/dashboard/ManageClusterView.vue
@@ -27,10 +27,19 @@
               <v-icon icon="mdi-eye" class="mr-2"></v-icon>
               Show Kubeconfig
             </v-btn>
-            <v-btn variant="outlined" class="btn btn-outline" @click="openEditClusterNodesDialog">
-              <v-icon icon="mdi-pencil" class="mr-2"></v-icon>
-              Add Node
-            </v-btn>
+
+            <v-tooltip location="top" :disabled="haveEnoughBalance">
+              <template #activator="{ props }">
+                <div v-bind="props">
+                  <v-btn variant="outlined" :disabled="!haveEnoughBalance" class="btn btn-outline" @click="openEditClusterNodesDialog">
+                    <v-icon icon="mdi-pencil" class="mr-2"></v-icon>
+                    Add Node
+                  </v-btn>
+                </div>
+              </template>
+              <span>Insufficient balance. Minimum 5 TFT required to add nodes.</span>
+            </v-tooltip>
+
             <v-btn variant="outlined" class="btn btn-outline" color="error" @click="openDeleteModal">
               <v-icon icon="mdi-delete" class="mr-2"></v-icon>
               Delete
@@ -189,6 +198,15 @@ import { api } from '../../utils/api'
 
 import { formatDate } from '../../utils/dateUtils'
 import { userService } from '@/utils/userService'
+import { useUserStore } from '@/stores/user'
+
+const userStore = useUserStore()
+
+const haveEnoughBalance = computed(() => {
+  console.log('Balance check:', userStore.netBalance, 'Have enough:', userStore.netBalance >= 5)
+  return userStore.netBalance >= 5
+})
+
 
 // Import dialogs
 const EditClusterNodesDialog = defineAsyncComponent(() => import('./EditClusterNodesDialog.vue'))


### PR DESCRIPTION

<img width="1572" height="854" alt="image" src="https://github.com/user-attachments/assets/a633b2e6-1c29-4fc6-9553-3f27ad0339d3" />
<img width="1572" height="854" alt="image" src="https://github.com/user-attachments/assets/34469c6d-1e50-473e-b06b-9c6d15c3e2e2" />



### Changes

- added tooltip on disabled buttons due to insufficient balance
- show the insufficient balance only if the cluster is empty

### Related Issues

- #457 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstring
