### PR TITLE
fix: pass nodeId parameter through unreserveNode call to track node status 

### DIFF
--- a/frontend/kubecloud/src/components/dashboard/NodesCard.vue
+++ b/frontend/kubecloud/src/components/dashboard/NodesCard.vue
@@ -191,7 +191,7 @@ const handleUnreserve = async () => {
   if (!selectedNode.value?.rentContractId) return
   unreservingNode.value = selectedNode.value.rentContractId.toString()
   try {
-    await unreserveNode(selectedNode.value.rentContractId.toString())
+    await unreserveNode(selectedNode.value.rentContractId.toString(), selectedNode.value.nodeId)
     showUnreserveDialog.value = false
     selectedNode.value = null
   } catch (err) {

--- a/frontend/kubecloud/src/composables/useNodeManagement.ts
+++ b/frontend/kubecloud/src/composables/useNodeManagement.ts
@@ -167,10 +167,12 @@ export function useNodeManagement() {
   }
 
   // Unreserve a node
-  async function unreserveNode(contractId: string) {
-    await userService.unreserveNode(contractId)
+  async function unreserveNode(contractId: string, nodeId: number) {
+    await userService.unreserveNode(contractId, nodeId)
     // Optimistically remove the node from the list
-    rentedNodes.value = rentedNodes.value.filter(node => node.rentContractId?.toString() !== contractId)
+    rentedNodes.value = rentedNodes.value.filter(
+      (node) => node.rentContractId?.toString() !== contractId,
+    )
   }
 
   // Add node to deployment

--- a/frontend/kubecloud/src/utils/userService.ts
+++ b/frontend/kubecloud/src/utils/userService.ts
@@ -194,7 +194,7 @@ export class UserService {
   }
 
   // Unreserve a node
-  async unreserveNode(contractId: string) {
+  async unreserveNode(contractId: string, nodeId: number) {
     const response = await api.delete<ApiResponse<UnreserveNodeResponse>>(`/v1/user/nodes/unreserve/${contractId}`, { requiresAuth: true, showNotifications: true })
     // const workflowChecker = createWorkflowStatusChecker(response.data.data.workflow_id, { initialDelay: 3000, interval: 1000 })
     // const status = await workflowChecker.status
@@ -207,7 +207,7 @@ export class UserService {
     // }
     // if (status === WorkflowStatus.StatusCompleted) {
       try {
-        await this.trackNodeStatus(response.data.data.contract_id, "rentable")
+        await this.trackNodeStatus(nodeId, "rentable")
         useNotificationStore().success(
           'Node Unreservation Success',
           'Node has been successfully unreserved.',


### PR DESCRIPTION

### Description

was looking for the node status by tracking the contract id, now we are passing both node id and contract id to the unreserve function 


### Related Issues

- #225 

### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstring
