### PR TITLE
fix: handle node null

### DIFF
--- a/frontend/kubecloud/src/utils/userService.ts
+++ b/frontend/kubecloud/src/utils/userService.ts
@@ -327,7 +327,7 @@ export class UserService {
       const intervalId = setInterval(async () => {
         const nodes = await this.listReservedNodes()
 
-        const node =(nodes?.data as {data: {nodes: {nodeId: number}[]}}).data.nodes.find((n) => n.nodeId === nodeId)
+        const node =(nodes?.data as {data: {nodes: {nodeId: number}[]}}).data.nodes?.find((n) => n.nodeId === nodeId)
         if((targetStatus === "rented" && node) || (targetStatus === "rentable" && !node)){
           clearInterval(intervalId)
           resolve(true)


### PR DESCRIPTION
handle nodes with null on unreserve to avoid infinite loading 

[#538](https://github.com/codescalers/kubecloud/issues/538)