### PR TITLE
fix(ui): Remove unwanted tooltip from NodeSelect component

### DIFF
--- a/frontend/kubecloud/src/components/ui/NodeSelect.vue
+++ b/frontend/kubecloud/src/components/ui/NodeSelect.vue
@@ -7,9 +7,9 @@
 		item-value="nodeId"
 		class="node-select"
 	>
-		<template #item="{ item, index, props: itemProps }">
+		<template #item="{ item, index, props: { title, ...rest } }">
 			<div>
-				<div v-bind="itemProps" class="node-option-row">
+				<div v-bind="rest" class="node-option-row">
 					<NodeInfoRow
 						:node="item.raw"
 						:get-node-resources="getResources"


### PR DESCRIPTION

Description:

This PR resolves an issue where hovering over items in the NodeSelect dropdown displayed an [object Object] tooltip.

The fix intercepts the props passed to the dropdown items and removes the title attribute before it's bound to the element, preventing the browser's default tooltip from appearing.### Related Issues



### Related issues
 - #598 
### Checklist

- [ ] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstring
