### PR TITLE
Fix clusters health check for deleted clusters

### DIFF
--- a/backend/internal/activities/workflow.go
+++ b/backend/internal/activities/workflow.go
@@ -60,6 +60,7 @@ func RegisterEWFWorkflows(
 	engine.Register(constants.StepSendEmailNotification, SendNotification(db, notificationService.GetNotifiers()[notification.ChannelEmail]))
 	engine.Register(constants.StepSendUINotification, SendNotification(db, notificationService.GetNotifiers()[notification.ChannelUI]))
 	engine.Register(constants.StepVerifyNodeState, VerifyNodeStateStep(proxyClient))
+	engine.Register(constants.StepVerifyClusterInDB, VerifyClusterInDBStep(db))
 
 	registerWorkflowTemplate := newKubecloudWorkflowTemplate(notificationService)
 	registerWorkflowTemplate.BeforeWorkflowHooks = []ewf.BeforeWorkflowHook{
@@ -142,6 +143,7 @@ func RegisterEWFWorkflows(
 
 	trackClusterHealthWFTemplate := newKubecloudWorkflowTemplate(notificationService)
 	trackClusterHealthWFTemplate.Steps = []ewf.Step{
+		{Name: constants.StepVerifyClusterInDB, RetryPolicy: standardRetryPolicy},
 		{Name: constants.StepFetchKubeconfig, RetryPolicy: standardRetryPolicy},
 		{Name: constants.StepVerifyClusterReady, RetryPolicy: standardRetryPolicy},
 	}

--- a/backend/internal/constants/constants.go
+++ b/backend/internal/constants/constants.go
@@ -48,6 +48,7 @@ const (
 	StepSendEmailNotification   = "send-email-notification"
 	StepSendUINotification      = "send-ui-notification"
 	StepVerifyNodeState         = "verify-node-state"
+	StepVerifyClusterInDB       = "verify-cluster-in-db"
 
 	NodeRentable = "rentable"
 	NodeRented   = "rented"


### PR DESCRIPTION
### Description
The health check pulls all clusters from the database, but by the time the goroutine runs, a cluster may have been deleted. I added an initial step to the workflow to verify the cluster still exists. if it doesn’t, the workflow fails and no notification is sent.
### Changes

### Related Issues
https://github.com/codescalers/kubecloud/issues/651

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
