### PR TITLE
fix trailing slash routing issue

### DIFF
--- a/frontend/kubecloud/nginx.conf
+++ b/frontend/kubecloud/nginx.conf
@@ -6,6 +6,6 @@ server {
   index index.html;
 
   location / {
-    try_files $uri $uri/ /index.html;
+    try_files $uri /index.html;
   }
 } 

--- a/frontend/kubecloud/src/router/index.ts
+++ b/frontend/kubecloud/src/router/index.ts
@@ -158,7 +158,17 @@ router.beforeEach(async (to, _from, next) => {
   if (maintenanceHandled) {
     return
   }
-  
+
+  // Remove trailing slashes from paths (except root)
+  if (to.path !== '/' && to.path.endsWith('/')) {
+    const pathWithoutSlash = to.path.slice(0, -1)
+    return next({
+      path: pathWithoutSlash,
+      query: to.query,
+      hash: to.hash,
+    })
+  }
+
   // Check if user is authenticated
   const isAuthenticated = userStore.isLoggedIn
 

--- a/frontend/kubecloud/vite.config.ts
+++ b/frontend/kubecloud/vite.config.ts
@@ -13,4 +13,5 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
+  base: '/',
 })


### PR DESCRIPTION
### Description

- Add base key in vite config, 
- in vue router, add a handler to remove the trainling slash
- for the nginx : 
     try_files $uri `$uri/` /index.html;
      - This will try $uri then `$uri/` as a directory looking for the index.html file, which is not the expected flow for Vue, so we remove it


### Changes

List of changes this PR includes

### Related Issues

- #692 

### Checklist

- [x] Tests included
- [x] Build pass
- [ ] Documentation
- [x] Code format and docstring
