### PR TITLE
Show action menu only if authed

### DIFF
--- a/frontend/kubecloud/src/components/NavBar.vue
+++ b/frontend/kubecloud/src/components/NavBar.vue
@@ -120,7 +120,7 @@
     </div>
   </nav>
 
-  <ActionMenu />
+  <ActionMenu v-if="isLoggedIn" />
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
The issue happened because the action menu was pulling workflows even before the user was authenticated which failed. That's why the user was being redirected to the sign-in page.

https://github.com/codescalers/kubecloud/issues/931