### PR TITLE
Debug mode check to gin mode

### DIFF
--- a/backend/internal/api/app/app.go
+++ b/backend/internal/api/app/app.go
@@ -43,7 +43,12 @@ type App struct {
 func NewApp(ctx context.Context, config cfg.Configuration) (*App, error) {
 	// Disable gin's default logging since we're using zerolog
 	gin.DisableConsoleColor()
+
 	gin.SetMode(gin.ReleaseMode)
+
+	if config.Debug {
+		gin.SetMode(gin.DebugMode)
+	}
 
 	// Create router without default middleware
 	router := gin.New()


### PR DESCRIPTION
### Description

added debug mode check to gin mode instead of always passing release mode

### Changes

added debug mode check to gin mode instead of always passing release mode in `NewApp`

### Related Issues

https://github.com/codescalers/kubecloud/issues/823

### Checklist

- [ ] Tests included
- [ ] Build pass
- [ ] Documentation
- [ ] Code format and docstring
